### PR TITLE
active/idle bug fix

### DIFF
--- a/juju/actions.go
+++ b/juju/actions.go
@@ -1,0 +1,37 @@
+package juju
+
+import (
+	"context"
+
+	"github.com/juju/juju/api/client/action"
+)
+
+type actionsClient struct {
+	ConnectionFactory
+}
+
+func newActionsClient(cf ConnectionFactory) *actionsClient {
+	return &actionsClient{
+		ConnectionFactory: cf,
+	}
+}
+
+func (c *actionsClient) EnqueueOperation(ctx context.Context, actions []action.Action, modelUUID string) (action.EnqueuedActions, error) {
+	conn, err := c.GetConnection(ctx, &modelUUID)
+	if err != nil {
+		return action.EnqueuedActions{}, err
+	}
+	client := action.NewClient(conn)
+
+	return client.EnqueueOperation(actions)
+}
+
+func (c *actionsClient) GetOperation(ctx context.Context, operationID string, modelUUID string) (action.Operation, error) {
+	conn, err := c.GetConnection(ctx, &modelUUID)
+	if err != nil {
+		return action.Operation{}, err
+	}
+	client := action.NewClient(conn)
+
+	return client.Operation(operationID)
+}

--- a/juju/applications.go
+++ b/juju/applications.go
@@ -518,6 +518,11 @@ func (c applicationsClient) AreApplicationUnitsActiveIdle(ctx context.Context, i
 		return false, err
 	}
 
+	if len(readAppResponse.Status.Units) < 1 {
+		log.Info("application has no units", "app status", readAppResponse.Status)
+		return false, nil
+	}
+
 	for _, unit := range readAppResponse.Status.Units {
 		if unit.WorkloadStatus.Status != "active" || unit.AgentStatus.Status != "idle" {
 			log.Info("unit is not active/idle", "app status", readAppResponse.Status)

--- a/juju/client.go
+++ b/juju/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	Applications applicationsClient
 	Integrations integrationsClient
 	Users        usersClient
+	Actions      actionsClient
 }
 
 type ConnectionFactory struct {
@@ -51,6 +52,7 @@ func NewClient(config Configuration) (*Client, error) {
 		Applications: *newApplicationClient(cf),
 		Integrations: *newIntegrationsClient(cf),
 		Users:        *newUsersClient(cf),
+		Actions:      *newActionsClient(cf),
 	}, nil
 }
 


### PR DESCRIPTION
If an application has 0 units, it will incorrectly be reported as active/idle. This resolves the problem by returning false for active/idle if an application has no units to check. 

previously this function was only called on applications that had units present, but when using it for the control plane application this bug was discovered. 

