### PR TITLE
Active/idle bugfix and actions support

### DIFF
--- a/controllers/jujumachine_controller.go
+++ b/controllers/jujumachine_controller.go
@@ -255,7 +255,7 @@ func (r *JujuMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	machineID := *jujuMachine.Spec.MachineID
 	appsReady, err := r.reconcileApplications(ctx, machine, client, modelUUID, machineID)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("failed to add units to the machine"))
+		log.Error(err, "failed to add units to the machine")
 		return ctrl.Result{}, err
 	}
 
@@ -309,7 +309,7 @@ func (r *JujuMachineReconciler) reconcileApplications(ctx context.Context, machi
 				ModelUUID:       modelUUID,
 				NumUnits:        1,
 				Placement: []*instance.Placement{
-					&instance.Placement{
+					{
 						Scope:     instance.MachineScope,
 						Directive: machineID,
 					},

--- a/juju/actions.go
+++ b/juju/actions.go
@@ -10,20 +10,32 @@ type actionsClient struct {
 	ConnectionFactory
 }
 
+type EnqueueOperationInput struct {
+	Receiver   string
+	Name       string
+	Parameters map[string]interface{}
+}
+
 func newActionsClient(cf ConnectionFactory) *actionsClient {
 	return &actionsClient{
 		ConnectionFactory: cf,
 	}
 }
 
-func (c *actionsClient) EnqueueOperation(ctx context.Context, actions []action.Action, modelUUID string) (action.EnqueuedActions, error) {
+func (c *actionsClient) EnqueueOperation(ctx context.Context, input EnqueueOperationInput, modelUUID string) (action.EnqueuedActions, error) {
 	conn, err := c.GetConnection(ctx, &modelUUID)
 	if err != nil {
 		return action.EnqueuedActions{}, err
 	}
 	client := action.NewClient(conn)
 
-	return client.EnqueueOperation(actions)
+	act := action.Action{
+		Receiver:   input.Receiver,
+		Name:       input.Name,
+		Parameters: input.Parameters,
+	}
+	acts := []action.Action{act}
+	return client.EnqueueOperation(acts)
 }
 
 func (c *actionsClient) GetOperation(ctx context.Context, operationID string, modelUUID string) (action.Operation, error) {

--- a/juju/actions.go
+++ b/juju/actions.go
@@ -1,0 +1,37 @@
+package juju
+
+import (
+	"context"
+
+	"github.com/juju/juju/api/client/action"
+)
+
+type actionsClient struct {
+	ConnectionFactory
+}
+
+func newActionsClient(cf ConnectionFactory) *actionsClient {
+	return &actionsClient{
+		ConnectionFactory: cf,
+	}
+}
+
+func (c *actionsClient) EnqueueOperation(ctx context.Context, actions []action.Action, modelUUID string) (action.EnqueuedActions, error) {
+	conn, err := c.GetConnection(ctx, &modelUUID)
+	if err != nil {
+		return action.EnqueuedActions{}, err
+	}
+	client := action.NewClient(conn)
+
+	return client.EnqueueOperation(actions)
+}
+
+func (c *actionsClient) GetOperation(ctx context.Context, operationID string, modelUUID string) (action.Operation, error) {
+	conn, err := c.GetConnection(ctx, &modelUUID)
+	if err != nil {
+		return action.Operation{}, err
+	}
+	client := action.NewClient(conn)
+
+	return client.Operation(operationID)
+}

--- a/juju/applications.go
+++ b/juju/applications.go
@@ -518,6 +518,11 @@ func (c applicationsClient) AreApplicationUnitsActiveIdle(ctx context.Context, i
 		return false, err
 	}
 
+	if len(readAppResponse.Status.Units) < 1 {
+		log.Info("application has no units", "app status", readAppResponse.Status)
+		return false, nil
+	}
+
 	for _, unit := range readAppResponse.Status.Units {
 		if unit.WorkloadStatus.Status != "active" || unit.AgentStatus.Status != "idle" {
 			log.Info("unit is not active/idle", "app status", readAppResponse.Status)

--- a/juju/client.go
+++ b/juju/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	Applications applicationsClient
 	Integrations integrationsClient
 	Users        usersClient
+	Actions      actionsClient
 }
 
 type ConnectionFactory struct {
@@ -51,6 +52,7 @@ func NewClient(config Configuration) (*Client, error) {
 		Applications: *newApplicationClient(cf),
 		Integrations: *newIntegrationsClient(cf),
 		Users:        *newUsersClient(cf),
+		Actions:      *newActionsClient(cf),
 	}, nil
 }
 


### PR DESCRIPTION
This PR fixes an issue in the helper function for checking if all units of an application are active/idle. Previously it would return true for apps that had 0 units, now it correctly reports false for that case since there are no units to check status on. 

It also adds support for enqueueing actions, this is used in the control plane provider to get the kubeconfig from the kcp leader unit. 

