### PR TITLE
Configure kubernetes-worker to ignore missing CNI and skip ingress

### DIFF
--- a/config/samples/v1beta1_machinedeployment.yaml
+++ b/config/samples/v1beta1_machinedeployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: machinedeployment-sample
+spec:
+  clusterName: cluster-sample
+  replicas: 1
+  template:
+    spec:
+      clusterName: cluster-sample
+      bootstrap:
+        configRef:
+          name: charmedk8sconfig-machinedeployment
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: CharmedK8sConfigTemplate
+      infrastructureRef:
+        name: jujumachinetemplate-machinedeployment
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: JujuMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: JujuMachineTemplate
+metadata:
+  name: jujumachinetemplate-machinedeployment
+spec:
+  template:
+    spec:
+      constraints: "cores=2,mem=8G,root-disk=16G"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: CharmedK8sConfigTemplate
+metadata:
+  name: charmedk8sconfig-machinedeployment
+spec:
+  template:
+    spec:
+      workerApplications:
+        - kubernetes-worker

--- a/controllers/jujucluster_controller.go
+++ b/controllers/jujucluster_controller.go
@@ -890,6 +890,10 @@ func createApplicationsIfNeeded(ctx context.Context, jujuCluster *infrastructure
 			CharmChannel:    "1.27/edge",
 			CharmBase:       "ubuntu@22.04",
 			Units:           0,
+			Config: map[string]interface{}{
+				"ignore-missing-cni": true,
+				"ingress":            false,
+			},
 		},
 		{
 			ApplicationName: "etcd",


### PR DESCRIPTION
Disable missing CNI alerts on kubernetes-worker, which should let cluster machines progress to ready.

I've also disabled ingress here, which will prevent the deployment of nginx-ingress-controller into the Kubernetes cluster. I don't know if this is strictly necessary, but it seems appropriate given that we're disabling addons in kubernetes-control-plane too.

I haven't tested this yet, but will give it a go today.