### PR TITLE
Add metadata.yaml, make draft-release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,11 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 0
+  minor: 1
+  contract: v1beta1


### PR DESCRIPTION
Add bits to publish GitHub releases as provider repositories, per the [clusterctl provider contract](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html). When release time comes we should be able to run:

```
make draft-release RELEASE_TAG=v0.1.0
```

which will create a GitHub draft release that includes two assets: `metadata.yaml` and `infrastructure-components.yaml`. We can then review and publish the release, which will allow it to be used as a clusterctl provider repository.