### PR TITLE
update makefile to use deploy img var when creating components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,13 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 
 .PHONY: components
 components: manifests kustomize ## Produce the components yaml
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${DEPLOY_IMG}
 	echo "---" > $(COMPSFILE)
 	$(KUSTOMIZE) build config/default/ >> $(COMPSFILE)
 


### PR DESCRIPTION
components rule was updated to use the DEPLOY_IMG var when generating components. This allows us to use a dynamic tag for the image instead of relying on the default latest tag thats in the manager kustomization.yaml

docker buildx command was missing the directory argument so that was added so that we can produce multiarch images
