### PR TITLE
Parsing fix for microk8s clouds and integration tests

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - name: Set env
+      - name: Set cluster resources env
         # the cluster resources are expected to be provided to pytest as an env var which holds a base64 encoded string
         # since it will be a multiline env var special care is needed
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -38,13 +38,22 @@ jobs:
         run: echo "$DOCKERHUB_PASSWORD"
       - name: Test creds
         run: echo "$B64_CREDS" 
+      - name: Test branch name
+        run: echo "$GITHUB_REF_NAME" 
       
 
 # jobs:
 #   integration-test:
 #     name: VSphere Integration Test
 #     runs-on: self-hosted
-#     timeout-minutes: 120
+#     timeout-minutes: 180
+#     env: 
+#       # These secrets are repository secrets
+#       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+#       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+#       B64_CREDS: ${{ secrets.B64_ENCODED_CI_CREDS }}
+#       # GITHUB_TOKEN is an automatically included secret available to the workflow
+#       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #     steps:
 #       - name: Check out code
 #         uses: actions/checkout@v3
@@ -66,7 +75,7 @@ jobs:
 #             --model-default primary-network=VLAN_2763
 #             --model-default force-vm-hardware-version=17
 #       - name: Run test
-#         run: tox -e integration -- --basetemp=/home/ubuntu/pytest
+#         run: tox -c cluster-api-charmed-k8s-e2e -e integration -- --infra-branch=parsing-fix-for-microk8s-clouds --control-plane-branch=parsing-fix --metallb-ip-range=10.246.153.239-10.246.153.239
 #       - name: Setup Debug Artifact Collection
 #         if: ${{ failure() }}
 #         run: mkdir tmp

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -23,7 +23,7 @@ jobs:
           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
       - name: Test
-        run: echo $B64_RESOURCES
+        run: echo $B64_RESOURCES | base64 -d 
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -12,10 +12,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
+      # - name: Set env
+      #   run: echo "B64_RESOURCES=$(base64 test/data/ci-resources.yaml)" >> $GITHUB_ENV
+      # - name: Test
+      #   run: echo $B64_RESOURCES
       - name: Set env
-        run: echo "B64_RESOURCES=$(base64 test/data/ci-resources.yaml)" >> $GITHUB_ENV
-      - name: Test
-        run: echo $B64_RESOURCES
+        run: base64 test/data/ci-resources.yaml
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -21,13 +21,7 @@ jobs:
           submodules: 'true'
       - name: Set cluster resources env
         # the cluster resources are expected to be provided to pytest as an env var which holds a base64 encoded string
-        # since it will be a multiline env var special care is needed
-        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-        run: |
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
-          base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
-          echo "$EOF" >> "$GITHUB_ENV"
+        run: echo "B64_RESOURCES=$(base64 -w0 test/data/ci-resources.yaml)" >> $GITHUB_ENV
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-        submodules: 'true'
+          submodules: 'true'
       - name: Set env
         run: echo "B64_RESOURCES=$(base64 test/data/ci-resources.yaml)" >> $GITHUB_ENV
       - name: Test

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,0 +1,62 @@
+name: Test Suite
+on:
+  pull_request:
+
+jobs:
+  integration-test:
+    name: VSphere Integration Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+        submodules: 'true'
+      - name: Set env
+        run: echo "B64_RESOURCES=$(base64 test/data/ci-resources.yaml)" >> $GITHUB_ENV
+      - name: Test
+        run: echo $B64_RESOURCES
+      
+
+# jobs:
+#   integration-test:
+#     name: VSphere Integration Test
+#     runs-on: self-hosted
+#     timeout-minutes: 120
+#     steps:
+#       - name: Check out code
+#         uses: actions/checkout@v3
+#       - name: Setup Python
+#         uses: actions/setup-python@v4
+#         with:
+#           python-version: 3.8
+#       - name: Setup operator environment
+#         uses: charmed-kubernetes/actions-operator@main
+#         with:
+#           provider: vsphere
+#           juju-channel: 3.1/stable
+#           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
+#           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
+#           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
+#           bootstrap-options: >-
+#             ${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }}
+#             --model-default datastore=vsanDatastore
+#             --model-default primary-network=VLAN_2763
+#             --model-default force-vm-hardware-version=17
+#       - name: Run test
+#         run: tox -e integration -- --basetemp=/home/ubuntu/pytest
+#       - name: Setup Debug Artifact Collection
+#         if: ${{ failure() }}
+#         run: mkdir tmp
+#       - name: Collect Juju Status
+#         if: ${{ failure() }}
+#         run: |
+#           juju status 2>&1 | tee tmp/juju-status.txt
+#           juju-crashdump -s -m controller -a debug-layer -a config -o tmp/
+#           mv juju-crashdump-* tmp/ | true
+#       - name: Upload debug artifacts
+#         if: ${{ failure() }}
+#         uses: actions/upload-artifact@v3
+#         with:
+#           name: test-run-artifacts
+#           path: tmp

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -19,11 +19,19 @@ jobs:
           echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
+          echo "B64_CREDS<<$EOF" >> "$GITHUB_ENV"
+          base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
           echo "GH_TOKEN=some_token" >> "$GITHUB_ENV"
+          echo "DOCKERHUB_USERNAME=some_username" >> "$GITHUB_ENV"
+          echo "DOCKERHUB_PASSWORD=some_password" >> "$GITHUB_ENV"
       - name: Test
         run: |
           echo "$B64_RESOURCES" | base64 -d 
-          echo "$GH_TOKEN" 
+          echo "\n$GH_TOKEN" 
+          echo "\n$DOCKERHUB_USERNAME" 
+          echo "\n$DOCKERHUB_PASSWORD"
+          echo "\n$B64_CREDS" | base64 -d 
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -7,24 +7,27 @@ jobs:
     name: VSphere Integration Test
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env: 
+      # These secrets are repository secrets
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      B64_CREDS: ${{ secrets.B64_ENCODED_CI_CREDS }}
+      # GITHUB_TOKEN is an automatically included secret available to the workflow
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
           submodules: 'true'
-      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
       - name: Set env
+        # the cluster resources are expected to be provided to pytest as an env var which holds a base64 encoded string
+        # since it will be a multiline env var special care is needed
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
-          echo "B64_CREDS<<$EOF" >> "$GITHUB_ENV"
-          base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
-          echo "$EOF" >> "$GITHUB_ENV"
-          echo "GH_TOKEN=some_token" >> "$GITHUB_ENV"
-          echo "DOCKERHUB_USERNAME=some_username" >> "$GITHUB_ENV"
-          echo "DOCKERHUB_PASSWORD=some_password" >> "$GITHUB_ENV"
       - name: Test resources
         run: echo "$B64_RESOURCES" | base64 -d 
       - name: Test token
@@ -34,7 +37,7 @@ jobs:
       - name: Test password
         run: echo "$DOCKERHUB_PASSWORD"
       - name: Test creds
-        run: echo "$B64_CREDS" | base64 -d 
+        run: echo "$B64_CREDS" 
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -17,7 +17,13 @@ jobs:
       # - name: Test
       #   run: echo $B64_RESOURCES
       - name: Set env
-        run: base64 test/data/ci-resources.yaml
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
+          base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
+      - name: Test
+        run: echo $B64_RESOURCES
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -12,18 +12,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
-      # - name: Set env
-      #   run: echo "B64_RESOURCES=$(base64 test/data/ci-resources.yaml)" >> $GITHUB_ENV
-      # - name: Test
-      #   run: echo $B64_RESOURCES
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
       - name: Set env
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
+          echo "GH_TOKEN=some_token" >> "$GITHUB_ENV"
       - name: Test
-        run: echo "$B64_RESOURCES" | base64 -d 
+        run: |
+          echo "$B64_RESOURCES" | base64 -d 
+          echo "$GH_TOKEN" 
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -25,13 +25,16 @@ jobs:
           echo "GH_TOKEN=some_token" >> "$GITHUB_ENV"
           echo "DOCKERHUB_USERNAME=some_username" >> "$GITHUB_ENV"
           echo "DOCKERHUB_PASSWORD=some_password" >> "$GITHUB_ENV"
-      - name: Test
-        run: |
-          echo "$B64_RESOURCES" | base64 -d 
-          echo "\n$GH_TOKEN" 
-          echo "\n$DOCKERHUB_USERNAME" 
-          echo "\n$DOCKERHUB_PASSWORD"
-          echo "\n$B64_CREDS" | base64 -d 
+      - name: Test resources
+        run: echo "$B64_RESOURCES" | base64 -d 
+      - name: Test token
+        run: echo "$GH_TOKEN" 
+      - name: Test username
+        run: echo "$DOCKERHUB_USERNAME" 
+      - name: Test password
+        run: echo "$DOCKERHUB_PASSWORD"
+      - name: Test creds
+        run: echo "$B64_CREDS" | base64 -d 
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -23,7 +23,7 @@ jobs:
           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
       - name: Test
-        run: echo $B64_RESOURCES | base64 -d 
+        run: echo "$B64_RESOURCES" | base64 -d 
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Test creds
         run: echo "$B64_CREDS" 
       - name: Test branch name
-        run: echo "$GITHUB_REF_NAME" 
+        run: echo "$GITHUB_HEAD_REF" 
       
 
 # jobs:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -2,51 +2,11 @@ name: Test Suite
 on:
   pull_request:
 
-# jobs:
-#   integration-test:
-#     name: VSphere Integration Test
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 120
-#     env: 
-#       # These secrets are repository secrets
-#       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-#       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-#       B64_CREDS: ${{ secrets.B64_ENCODED_CI_CREDS }}
-#       # GITHUB_TOKEN is an automatically included secret available to the workflow
-#       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#     steps:
-#       - name: Check out code
-#         uses: actions/checkout@v3
-#         with:
-#           submodules: 'true'
-#       - name: Set cluster resources env
-#         # the cluster resources are expected to be provided to pytest as an env var which holds a base64 encoded string
-#         # since it will be a multiline env var special care is needed
-#         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-#         run: |
-#           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-#           echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
-#           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
-#           echo "$EOF" >> "$GITHUB_ENV"
-#       - name: Test resources
-#         run: echo "$B64_RESOURCES" | base64 -d 
-#       - name: Test token
-#         run: echo "$GH_TOKEN" 
-#       - name: Test username
-#         run: echo "$DOCKERHUB_USERNAME" 
-#       - name: Test password
-#         run: echo "$DOCKERHUB_PASSWORD"
-#       - name: Test creds
-#         run: echo "$B64_CREDS" 
-#       - name: Test branch name
-#         run: echo "$GITHUB_HEAD_REF" 
-      
-
 jobs:
   integration-test:
     name: VSphere Integration Test
     runs-on: self-hosted
-    timeout-minutes: 180
+    timeout-minutes: 120
     env: 
       # These secrets are repository secrets
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -2,11 +2,51 @@ name: Test Suite
 on:
   pull_request:
 
+# jobs:
+#   integration-test:
+#     name: VSphere Integration Test
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 120
+#     env: 
+#       # These secrets are repository secrets
+#       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+#       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+#       B64_CREDS: ${{ secrets.B64_ENCODED_CI_CREDS }}
+#       # GITHUB_TOKEN is an automatically included secret available to the workflow
+#       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#     steps:
+#       - name: Check out code
+#         uses: actions/checkout@v3
+#         with:
+#           submodules: 'true'
+#       - name: Set cluster resources env
+#         # the cluster resources are expected to be provided to pytest as an env var which holds a base64 encoded string
+#         # since it will be a multiline env var special care is needed
+#         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+#         run: |
+#           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+#           echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
+#           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
+#           echo "$EOF" >> "$GITHUB_ENV"
+#       - name: Test resources
+#         run: echo "$B64_RESOURCES" | base64 -d 
+#       - name: Test token
+#         run: echo "$GH_TOKEN" 
+#       - name: Test username
+#         run: echo "$DOCKERHUB_USERNAME" 
+#       - name: Test password
+#         run: echo "$DOCKERHUB_PASSWORD"
+#       - name: Test creds
+#         run: echo "$B64_CREDS" 
+#       - name: Test branch name
+#         run: echo "$GITHUB_HEAD_REF" 
+      
+
 jobs:
   integration-test:
     name: VSphere Integration Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+    runs-on: self-hosted
+    timeout-minutes: 180
     env: 
       # These secrets are repository secrets
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -28,66 +68,37 @@ jobs:
           echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
           base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
-      - name: Test resources
-        run: echo "$B64_RESOURCES" | base64 -d 
-      - name: Test token
-        run: echo "$GH_TOKEN" 
-      - name: Test username
-        run: echo "$DOCKERHUB_USERNAME" 
-      - name: Test password
-        run: echo "$DOCKERHUB_PASSWORD"
-      - name: Test creds
-        run: echo "$B64_CREDS" 
-      - name: Test branch name
-        run: echo "$GITHUB_HEAD_REF" 
-      
-
-# jobs:
-#   integration-test:
-#     name: VSphere Integration Test
-#     runs-on: self-hosted
-#     timeout-minutes: 180
-#     env: 
-#       # These secrets are repository secrets
-#       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-#       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-#       B64_CREDS: ${{ secrets.B64_ENCODED_CI_CREDS }}
-#       # GITHUB_TOKEN is an automatically included secret available to the workflow
-#       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#     steps:
-#       - name: Check out code
-#         uses: actions/checkout@v3
-#       - name: Setup Python
-#         uses: actions/setup-python@v4
-#         with:
-#           python-version: 3.8
-#       - name: Setup operator environment
-#         uses: charmed-kubernetes/actions-operator@main
-#         with:
-#           provider: vsphere
-#           juju-channel: 3.1/stable
-#           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
-#           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
-#           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-#           bootstrap-options: >-
-#             ${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }}
-#             --model-default datastore=vsanDatastore
-#             --model-default primary-network=VLAN_2763
-#             --model-default force-vm-hardware-version=17
-#       - name: Run test
-#         run: tox -c cluster-api-charmed-k8s-e2e -e integration -- --infra-branch=parsing-fix-for-microk8s-clouds --control-plane-branch=parsing-fix --metallb-ip-range=10.246.153.239-10.246.153.239
-#       - name: Setup Debug Artifact Collection
-#         if: ${{ failure() }}
-#         run: mkdir tmp
-#       - name: Collect Juju Status
-#         if: ${{ failure() }}
-#         run: |
-#           juju status 2>&1 | tee tmp/juju-status.txt
-#           juju-crashdump -s -m controller -a debug-layer -a config -o tmp/
-#           mv juju-crashdump-* tmp/ | true
-#       - name: Upload debug artifacts
-#         if: ${{ failure() }}
-#         uses: actions/upload-artifact@v3
-#         with:
-#           name: test-run-artifacts
-#           path: tmp
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: vsphere
+          juju-channel: 3.1/stable
+          credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
+          clouds-yaml: ${{ secrets.CLOUDS_YAML }}
+          bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
+          bootstrap-options: >-
+            ${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }}
+            --model-default datastore=vsanDatastore
+            --model-default primary-network=VLAN_2763
+            --model-default force-vm-hardware-version=17
+      - name: Run test
+        run: tox -c cluster-api-charmed-k8s-e2e -e e2e -- --infra-branch=$GITHUB_HEAD_REF --control-plane-branch=parsing-fix --metallb-ip-range=10.246.153.239-10.246.153.239
+      - name: Setup Debug Artifact Collection
+        if: ${{ failure() }}
+        run: mkdir tmp
+      - name: Collect Juju Status
+        if: ${{ failure() }}
+        run: |
+          juju status 2>&1 | tee tmp/juju-status.txt
+          juju-crashdump -s -m controller -a debug-layer -a config -o tmp/
+          mv juju-crashdump-* tmp/ | true
+      - name: Upload debug artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-run-artifacts
+          path: tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cluster-api-charmed-k8s-e2e"]
 	path = cluster-api-charmed-k8s-e2e
 	url = https://github.com/charmed-kubernetes/cluster-api-charmed-k8s-e2e.git
-	branch = scp/testing
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "cluster-api-charmed-k8s-e2e"]
+	path = cluster-api-charmed-k8s-e2e
+	url = https://github.com/charmed-kubernetes/cluster-api-charmed-k8s-e2e.git
+	branch = scp/testing

--- a/controllers/jujucluster_controller.go
+++ b/controllers/jujucluster_controller.go
@@ -740,7 +740,7 @@ func getJujuConfigFromSecret(ctx context.Context, cluster *clusterv1.Cluster, ju
 		}
 	}
 	data := string(configSecret.Data["controller-data"][:])
-	split := strings.Split(data, fmt.Sprintf("%s:\n", jujuCluster.Name+"-k8s-cloud"))
+	split := strings.SplitN(data, ":\n", 2)
 	yam := split[1]
 	config := JujuConfig{}
 	err := yaml.Unmarshal([]byte(yam), &config)

--- a/test/data/ci-resources.yaml
+++ b/test/data/ci-resources.yaml
@@ -1,0 +1,197 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: JujuCluster
+metadata:
+  labels:
+    app.kubernetes.io/name: jujucluster
+    app.kubernetes.io/instance: jujucluster-sample
+    app.kubernetes.io/part-of: cluster-api-provider-juju
+    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: cluster-api-provider-juju
+  name: jujucluster-sample
+spec:
+  model:
+    name: jujucluster-sample
+    cloudRegion: Boston
+    config: 
+      juju-http-proxy: "http://squid.internal:3128"
+      apt-http-proxy: "http://squid.internal:3128"
+      snap-http-proxy: "http://squid.internal:3128"
+      juju-https-proxy: "http://squid.internal:3128"
+      apt-https-proxy: "http://squid.internal:3128"
+      snap-https-proxy: "http://squid.internal:3128"
+      apt-no-proxy: "localhost,127.0.0.1,ppa.launchpad.net,launchpad.net"
+      juju-no-proxy: "localhost,127.0.0.1,0.0.0.0,ppa.launchpad.net,launchpad.net,10.0.8.0/24,10.246.154.0/24,10.246.153.0/24"
+      logging-config: "<root>=DEBUG"
+      datastore: "vsanDatastore"
+      primary-network: "VLAN_2763"
+      force-vm-hardware-version: "17"
+    constraints:
+      arch: amd64
+  # using loadbalancer requires metallb on vsphere
+  controllerServiceType: loadbalancer
+  credential:
+    credentialSecretName: jujucluster-sample-credential-secret
+    credentialSecretNamespace: default
+  cloud:
+    name: jujucluster-sample
+    type: vsphere
+    endpoint: 10.246.152.100
+    regions:
+      - name: Boston
+        endpoint: 10.246.152.100
+    authTypes:
+      - "userpass"
+  defaultApplicationConfigs:
+    defaultChannel: 1.27/stable
+    defaultBase: ubuntu@22.04
+    kubernetesControlPlaneConfig:
+      options:
+        ignore-missing-cni: true
+        enable-metrics: false
+        enable-dashboard-addons: false
+        allow-privileged: "true"
+        ignore-kube-system-pods: "coredns vsphere-cloud-controller-manager"
+      channel: 1.27/stable
+      base: ubuntu@22.04
+      expose: true
+    kubernetesWorkerConfig:
+      options:
+        ignore-missing-cni: true
+        ingress: false
+      channel: 1.27/stable
+      base: ubuntu@22.04
+      expose: true
+    easyRSAConfig:
+      constraints:
+        cores: 1
+        mem: 4000
+        root-disk: 16000
+      channel: 1.27/stable
+      base: ubuntu@22.04
+    kubeApiLoadBalancerConfig:
+      constraints:
+        cores: 1
+        mem: 4000
+        root-disk: 16000
+      channel: 1.27/stable
+      base: ubuntu@22.04
+  additionalApplications:
+    applications:
+      vsphere-integrator:
+        charm: vsphere-integrator      
+        channel: 1.27/stable
+        base: ubuntu@22.04
+        numUnits: 1
+        options:   
+          datastore: vsanDatastore
+          folder: k8s-ci-root 
+        requiresTrust: true
+      vsphere-cloud-provider:
+        charm: vsphere-cloud-provider      
+        channel: 1.27/stable
+        base: ubuntu@22.04
+        numUnits: 0
+    integrations:
+      - - vsphere-cloud-provider:vsphere-integration
+        - vsphere-integrator:clients
+      - - vsphere-cloud-provider:certificates
+        - easyrsa:client
+      - - vsphere-cloud-provider:kube-control
+        - kubernetes-control-plane:kube-control
+      - - vsphere-cloud-provider:external-cloud-provider
+        - kubernetes-control-plane:external-cloud-provider
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-sample
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: JujuCluster
+    name: jujucluster-sample
+  controlPlaneRef:
+    kind: CharmedK8sControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: charmedk8scontrolplane-sample
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: JujuMachineTemplate
+metadata:
+  name: jujumachinetemplate-controlplane
+spec:
+  template:
+    spec:
+      useJujuProviderID: false
+      constraints: 
+        cores: 2
+        mem: 8000
+        root-disk: 16000
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: CharmedK8sControlPlane
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-sample
+    app.kubernetes.io/name: charmedk8scontrolplane
+    app.kubernetes.io/instance: charmedk8scontrolplane-sample
+    app.kubernetes.io/part-of: cluster-api-control-plane-provider-charmed-k8s
+    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: cluster-api-control-plane-provider-charmed-k8s
+  name: charmedk8scontrolplane-sample
+spec:
+  replicas: 1
+  machineTemplate:
+    kind: JujuMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    name: jujumachinetemplate-controlplane
+  controlPlaneConfig:
+    controlPlaneApplications:
+      - kubernetes-control-plane
+      - etcd
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: machinedeployment-sample
+spec:
+  clusterName: cluster-sample
+  replicas: 1
+  template:
+    spec:
+      clusterName: cluster-sample
+      bootstrap:
+        configRef:
+          name: charmedk8sconfig-machinedeployment
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: CharmedK8sConfigTemplate
+      infrastructureRef:
+        name: jujumachinetemplate-machinedeployment
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: JujuMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: JujuMachineTemplate
+metadata:
+  name: jujumachinetemplate-machinedeployment
+spec:
+  template:
+    spec:
+      useJujuProviderID: false
+      constraints: 
+        cores: 2
+        mem: 8000
+        root-disk: 16000
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: CharmedK8sConfigTemplate
+metadata:
+  name: charmedk8sconfig-machinedeployment
+spec:
+  template:
+    spec:
+      workerApplications:
+        - kubernetes-worker


### PR DESCRIPTION
This PR adds the shared integration testing as a submodule, and fixes a bug when running in microk8s. We were previously operating under the assumption the controller namespace is named controller-{jujuclusterName}, however on some clouds juju appends additional information to the end of that, causing controller config parsing issues and issues with deletion of the controller namespace. Controller config parsing was simplified, and instead of directly deleting a namespace via a specific name, the current namespaces are searched for a name containing a substring and the matching namespace is deleted. 

This PR should not be merged until [the e2e tests](https://github.com/charmed-kubernetes/cluster-api-charmed-k8s-e2e/pull/2) are in main, at which point the submodule branch will need to be updated to point to main instead of the PR branch it currently points to. Then this can be merged

A second PR will be necessary after the merging of [the control plane PR](https://github.com/charmed-kubernetes/cluster-api-control-plane-provider-charmed-k8s/pull/10) in order to update the control plane branch name used in the tox invocation 